### PR TITLE
feat: add vaccinated data to home page

### DIFF
--- a/__factories__/districtFactory.ts
+++ b/__factories__/districtFactory.ts
@@ -1,0 +1,29 @@
+import { District } from "../interfaces";
+
+export default function districtFactory(params?: Partial<District>): District {
+  const defaultParams: District = {
+    country: "Brazil",
+    state: "DF",
+    totalCases: 268394,
+    totalCasesMS: 268394,
+    notConfirmedByMS: 0,
+    deaths: 4460,
+    deathsMS: 4460,
+    URL: "http://www.saude.df.gov.br/coronavirus/",
+    deaths_per_100k_inhabitants: 147.91388,
+    totalCases_per_100k_inhabitants: 8901.16567,
+    deaths_by_totalCases: 0.01662,
+    recovered: 257079,
+    suspects: 68,
+    tests: 771909,
+    tests_per_100k_inhabitants: 25600.013,
+    vaccinated: 15134,
+    vaccinated_per_100k_inhabitants: 501.91227,
+    date: "2021-01-22",
+    newCases: 1054,
+    newDeaths: 8,
+    lastUpdated: new Date(),
+  };
+
+  return { ...defaultParams, ...params };
+}

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,10 +1,18 @@
 import { render, screen } from "@testing-library/react";
 import "../__mocks__/match-media";
 import HomePage from "../pages";
+import districtFactory from "../__factories__/districtFactory";
+import { District } from "../interfaces";
 
 describe("HomePage", () => {
   it("should render the brazil map", () => {
-    render(<HomePage />);
+    const total = districtFactory({ state: "total" });
+    const ac = districtFactory({ state: "AC" });
+    const districts: District[] = [total, ac];
+    const updatedAt = new Date().toString();
+
+    render(<HomePage data={districts} updatedAt={updatedAt} />);
+
     expect(screen.getByLabelText("Map of Brazil")).toBeInTheDocument();
   });
 });

--- a/__tests__/utils/findDistrictById.test.ts
+++ b/__tests__/utils/findDistrictById.test.ts
@@ -1,0 +1,14 @@
+import findDistrictById from "../../utils/findDistrictById";
+import { District } from "../../interfaces";
+import districtFactory from "../../__factories__/districtFactory";
+
+describe("findDistrictById", () => {
+  it("returns a district by its ID", () => {
+    const df = districtFactory({ state: "DF" });
+    const ac = districtFactory({ state: "AC" });
+    const districts: District[] = [df, ac];
+    const district = findDistrictById(districts, "df");
+
+    expect(district?.state).toEqual("DF");
+  });
+});

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -22,7 +22,7 @@ export type District = {
   tests_per_100k_inhabitants: number;
   vaccinated: number;
   vaccinated_per_100k_inhabitants: number;
-  date: number;
+  date: string;
   newCases: number;
   newDeaths: number;
   lastUpdated: Date;

--- a/pages/api/districts/index.tsx
+++ b/pages/api/districts/index.tsx
@@ -1,0 +1,20 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { getCasesData } from "../../../services/casesData";
+
+const CACHE_CONTROL_HEADER_VALUE =
+  "max-age=0, s-maxage=7200, stale-while-revalidate, public";
+
+const action = async (_: NextApiRequest, res: NextApiResponse) => {
+  const districts = await getCasesData();
+
+  if (districts) {
+    res.setHeader("Cache-Control", CACHE_CONTROL_HEADER_VALUE);
+    res.status(200);
+    return res.json(districts);
+  }
+
+  res.status(404);
+  return res.json({ error: "no data found" });
+};
+
+export default action;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,8 @@ import { GetStaticProps } from "next";
 import Brazil from "../lib/custom-brazil.regions";
 import { DEFAULT_REVALIDATE_TIME } from "../utils/constants";
 import { District } from "../interfaces";
-import { getCasesData } from "../services/casesData";
 import findDistrictById from "../utils/findDistrictById";
+import { getCases } from "../services/api/cases";
 
 const { Footer, Content } = Layout;
 const { Title } = Typography;
@@ -59,7 +59,7 @@ const HomePage = ({ data, updatedAt }: Props) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const data = await getCasesData();
+  const data = await getCases();
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,36 +1,73 @@
 import { useState } from "react";
 import { SVGMap } from "react-svg-map";
 import { Row, Col, Typography, Layout } from "antd";
+import { GetStaticProps } from "next";
 import Brazil from "../lib/custom-brazil.regions";
+import { DEFAULT_REVALIDATE_TIME } from "../utils/constants";
+import { District } from "../interfaces";
+import { getCasesData } from "../services/casesData";
+import findDistrictById from "../utils/findDistrictById";
 
 const { Footer, Content } = Layout;
 const { Title } = Typography;
 
-const HomePage = () => {
-  const [district, setDistrict] = useState<string | null>("Brasil");
-  const districtName = (e: Event) =>
-    (e.target as HTMLElement).getAttribute("name");
+export type Props = {
+  data: District[];
+  updatedAt: string;
+};
+
+const HomePage = ({ data, updatedAt }: Props) => {
+  const [districtName, setDistrictName] = useState<string | null>("Brasil");
+  const [districtId, setDistrictId] = useState<string>("total");
+
+  const getEventAttribute = (event: Event, attribute: string) =>
+    (event.target as HTMLElement).getAttribute(attribute);
+
+  const setDistrict = (e: Event) => {
+    setDistrictName(getEventAttribute(e, "name"));
+    setDistrictId(getEventAttribute(e, "id") || "total");
+  };
+
+  const districtData = findDistrictById(data, districtId);
+
+  if (districtData)
+    return (
+      <Layout>
+        <Content className="container">
+          <Row>
+            <Col sm={24} md={12}>
+              <div className="map-container">
+                <SVGMap map={Brazil} onLocationClick={setDistrict} />
+              </div>
+            </Col>
+            <Col sm={24} md={12}>
+              <Title>Vacinômetro - {districtName}</Title>
+              <p>Vacinados: {districtData.vaccinated}</p>
+              <p>Última atualização: {updatedAt}</p>
+            </Col>
+          </Row>
+        </Content>
+        <Footer>Footer</Footer>
+      </Layout>
+    );
 
   return (
     <Layout>
-      <Content className="container">
-        <Row>
-          <Col sm={24} md={12}>
-            <div className="map-container">
-              <SVGMap
-                map={Brazil}
-                onLocationClick={(e) => setDistrict(districtName(e))}
-              />
-            </div>
-          </Col>
-          <Col sm={24} md={12}>
-            <Title>Vacinômetro - {district}</Title>
-          </Col>
-        </Row>
-      </Content>
-      <Footer>Footer</Footer>
+      <Content className="container">Sem informações</Content>
     </Layout>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const data = await getCasesData();
+
+  return {
+    props: {
+      data,
+      updatedAt: new Date().toString(),
+    },
+    revalidate: DEFAULT_REVALIDATE_TIME,
+  };
 };
 
 export default HomePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,7 @@ import Brazil from "../lib/custom-brazil.regions";
 import { DEFAULT_REVALIDATE_TIME } from "../utils/constants";
 import { District } from "../interfaces";
 import findDistrictById from "../utils/findDistrictById";
-import { getCases } from "../services/api/cases";
+import { getCasesData } from "../services/casesData";
 
 const { Footer, Content } = Layout;
 const { Title } = Typography;
@@ -59,7 +59,7 @@ const HomePage = ({ data, updatedAt }: Props) => {
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const data = await getCases();
+  const data = await getCasesData();
 
   return {
     props: {

--- a/services/api/cases.ts
+++ b/services/api/cases.ts
@@ -1,0 +1,6 @@
+import { baseUrl } from "./index";
+
+export const getCases = async () => {
+  const response = await fetch(`${baseUrl}districts`);
+  return response.json();
+};

--- a/services/api/index.ts
+++ b/services/api/index.ts
@@ -1,0 +1,4 @@
+export const baseUrl =
+  process.env.NODE_ENV === "production"
+    ? "https://vacinometro.com/api/"
+    : "http://localhost:3000/api/";

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,3 +1,4 @@
 export const DATA_INFO_URL = "https://covid19br.wcota.me/";
 export const CSV_DATA_INFO =
   "https://raw.githubusercontent.com/wcota/covid19br/master/cases-brazil-total.csv";
+export const DEFAULT_REVALIDATE_TIME = 7200; // 2 hours

--- a/utils/findDistrictById.ts
+++ b/utils/findDistrictById.ts
@@ -1,0 +1,14 @@
+import { District } from "../interfaces";
+
+const findDistrictById = (
+  districts: District[],
+  id: string,
+): District | undefined => {
+  const district = districts.find(
+    ({ state }) => state.toLowerCase() === id.toLowerCase(),
+  );
+
+  return district;
+};
+
+export default findDistrictById;


### PR DESCRIPTION
<!-- Delete as partes que não fizerem sentido -->

# Descrição
- Adiciona dados de vacinação na página inicial

# Como testar?
- Entre na página inicial e cheque se os dados dos estados aparecem ao clicar no mapa
